### PR TITLE
Use plan artifact for terraform apply

### DIFF
--- a/.github/workflows/aws-oidc-test.yml
+++ b/.github/workflows/aws-oidc-test.yml
@@ -1,8 +1,9 @@
+---
 name: tf-ci
-on:
+'on':
   pull_request:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
 
 permissions:
   id-token: write
@@ -64,8 +65,12 @@ jobs:
           role-to-assume: ${{ secrets.AWS_OIDC_ROLE_ARN }}
           aws-region: us-east-1
           role-session-name: gha-appstream
+      - uses: actions/download-artifact@v4
+        with:
+          name: tfplan
+          path: terraform
       - name: Terraform Apply (manual)
         working-directory: terraform
         run: |
           terraform init
-          terraform apply -var-file="terraform.tfvars" -auto-approve
+          terraform apply plan.out -auto-approve


### PR DESCRIPTION
## Summary
- download tfplan artifact before apply
- apply terraform plan file instead of var-file
- add yaml document header and formatting for lint

## Testing
- `yamllint .github/workflows/aws-oidc-test.yml && echo "yamllint passed"`


------
https://chatgpt.com/codex/tasks/task_e_68a17563da48832eb9dd784a078f5994