### PR TITLE
refactor: centralize AWS provider configuration

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,11 +9,6 @@ terraform {
   }
 }
 
-
-provider "aws" {
-  region = "us-east-1"
-}
-
 resource "aws_security_group" "appstream_sg" {
   name        = "appstream-sg"
   description = "Security group for AppStream fleet"
@@ -44,11 +39,11 @@ resource "aws_cloudformation_stack" "appstream_stack" {
   template_body = file("${path.module}/../cft/appstream-stack.yaml")
 
   parameters = {
-    VPCId           = var.vpc_id
-    SubnetIds       = join(",", var.subnet_ids)
-    SecurityGroupId = aws_security_group.appstream_sg.id
-    FleetName       = var.fleet_name
-    SessionTimeout  = var.session_timeout
+    VPCId             = var.vpc_id
+    SubnetIds         = join(",", var.subnet_ids)
+    SecurityGroupId   = aws_security_group.appstream_sg.id
+    FleetName         = var.fleet_name
+    SessionTimeout    = var.session_timeout
     EnableAutoScaling = var.enable_autoscaling
     DesiredCapacity   = var.desired_capacity
     MinCapacity       = var.min_capacity


### PR DESCRIPTION
## Summary
- remove inline AWS provider block from main Terraform module
- rely on providers.tf for region and profile settings

## Testing
- `terraform fmt -check main.tf`
- `terraform init -backend=false` *(fails: failed to query provider packages: Forbidden)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_68a1754b5fac832eae09519e31433c47