### PR TITLE
Conditionally create AppStream security group

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,6 +15,7 @@ provider "aws" {
 }
 
 resource "aws_security_group" "appstream_sg" {
+  count       = var.security_group_id == null ? 1 : 0
   name        = "appstream-sg"
   description = "Security group for AppStream fleet"
   vpc_id      = var.vpc_id
@@ -39,16 +40,20 @@ resource "aws_security_group" "appstream_sg" {
   }
 }
 
+locals {
+  effective_sg_id = var.security_group_id != null ? var.security_group_id : aws_security_group.appstream_sg[0].id
+}
+
 resource "aws_cloudformation_stack" "appstream_stack" {
   name          = var.stack_name
   template_body = file("${path.module}/../cft/appstream-stack.yaml")
 
   parameters = {
-    VPCId           = var.vpc_id
-    SubnetIds       = join(",", var.subnet_ids)
-    SecurityGroupId = aws_security_group.appstream_sg.id
-    FleetName       = var.fleet_name
-    SessionTimeout  = var.session_timeout
+    VPCId             = var.vpc_id
+    SubnetIds         = join(",", var.subnet_ids)
+    SecurityGroupId   = local.effective_sg_id
+    FleetName         = var.fleet_name
+    SessionTimeout    = var.session_timeout
     EnableAutoScaling = var.enable_autoscaling
     DesiredCapacity   = var.desired_capacity
     MinCapacity       = var.min_capacity


### PR DESCRIPTION
## Summary
- create AppStream security group only when no external ID is given
- expose selected security group ID via `effective_sg_id`

## Testing
- `terraform -chdir=terraform init -backend=false` (fails: Duplicate provider configuration)
- `terraform -chdir=terraform validate` (fails: Duplicate provider configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a1753f940c832eb08fb2766081df94