### PR TITLE
Use ubuntu-latest for branch naming workflow

### DIFF
--- a/.github/workflows/enforce-branch-naming.yml
+++ b/.github/workflows/enforce-branch-naming.yml
@@ -5,7 +5,7 @@ on:
       - "main"
 jobs:
   check-branch-name:
-    runs-on: ["linux", "ubuntu",  "docker", "shell", "backend"]
+    runs-on: ubuntu-latest
     steps:
       - name: Get Branch Name
         id: branch


### PR DESCRIPTION
## Summary
- simplify branch naming check workflow to run on ubuntu-latest
- ensure workflow file ends with a newline

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/appstream-vdi/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a1750505a0832e83e118a0e344c83c