### PR TITLE
Fix Terraform configuration for AppStream deployment

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,9 +36,7 @@ resource "aws_security_group" "appstream_sg" {
 }
 
 locals {
-codex/add-locals-block-and-update-outputs
   effective_sg_id = var.security_group_id != null ? var.security_group_id : aws_security_group.appstream_sg[0].id
-main
 }
 
 resource "aws_cloudformation_stack" "appstream_stack" {
@@ -46,23 +44,15 @@ resource "aws_cloudformation_stack" "appstream_stack" {
   template_body = file("${path.module}/../cft/appstream-stack.yaml")
 
   parameters = {
-
-    VPCId             = var.vpc_id
-    SubnetIds         = join(",", var.subnet_ids)
- codex/add-locals-block-and-update-outputs
-    SecurityGroupId   = local.effective_sg_id
-
-codex/modify-security-group-creation-logic-in-terraform
-    SecurityGroupId   = local.effective_sg_id
-main
- main
-    FleetName         = var.fleet_name
-    SessionTimeout    = var.session_timeout
-    EnableAutoScaling = var.enable_autoscaling
-    DesiredCapacity   = var.desired_capacity
-    MinCapacity       = var.min_capacity
-    MaxCapacity       = var.max_capacity
- main
+    VPCId                       = var.vpc_id
+    SubnetIds                   = join(",", var.subnet_ids)
+    SecurityGroupId             = local.effective_sg_id
+    FleetName                   = var.fleet_name
+    MaxUserSessionDurationHours = var.max_user_session_duration_hours
+    EnableAutoScaling           = var.enable_autoscaling
+    DesiredCapacity             = var.desired_capacity
+    MinCapacity                 = var.min_capacity
+    MaxCapacity                 = var.max_capacity
   }
 
   capabilities = ["CAPABILITY_NAMED_IAM"]

--- a/terraform/terraform.tfvars
+++ b/terraform/terraform.tfvars
@@ -1,7 +1,7 @@
-stack_name   = "webforx-appstream-vdi"
-region       = "us-east-1"
-environment  = "sandbox"
-project      = "appstream-vdi"
+stack_name  = "webforx-appstream-vdi"
+region      = "us-east-1"
+environment = "sandbox"
+project     = "appstream-vdi"
 
 vpc_id     = "vpc-xxxxxxxx"
 subnet_ids = ["subnet-aaaaaaa", "subnet-bbbbbbb"]
@@ -9,8 +9,8 @@ subnet_ids = ["subnet-aaaaaaa", "subnet-bbbbbbb"]
 # Optional: reuse an existing SG
 # security_group_id = "sg-xxxxxxxx"
 
-fleet_name          = "webforx-vdi-fleet"
-fleet_instance_type = "stream.standard.medium"
+fleet_name            = "webforx-vdi-fleet"
+fleet_instance_type   = "stream.standard.medium"
 builder_instance_type = "stream.standard.large"
 
 # Start cost-safe

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -73,3 +73,27 @@ variable "project" {
   description = "Project tag"
   default     = "appstream-vdi"
 }
+
+variable "fleet_instance_type" {
+  type        = string
+  description = "Instance type for the AppStream fleet (currently unused)"
+  default     = "stream.standard.medium"
+}
+
+variable "builder_instance_type" {
+  type        = string
+  description = "Instance type for the Image Builder (currently unused)"
+  default     = "stream.standard.large"
+}
+
+variable "business_hours_cron_start_utc" {
+  type        = string
+  description = "Cron expression to start fleet during business hours (currently unused)"
+  default     = "cron(0 13 * * ? *)"
+}
+
+variable "after_hours_cron_stop_utc" {
+  type        = string
+  description = "Cron expression to stop fleet after hours (currently unused)"
+  default     = "cron(0 22 * * ? *)"
+}


### PR DESCRIPTION
## Summary
- clean up Terraform `main.tf` by removing placeholder directives and aligning parameters with CloudFormation template
- add optional variables for fleet and schedule settings
- format Terraform files

## Testing
- `terraform fmt -recursive`
- `terraform init` (fails: could not connect to registry.terraform.io: Forbidden)
- `terraform validate` (fails: Missing required provider hashicorp/aws)


------
https://chatgpt.com/codex/tasks/task_e_68a183813e40832e858f6ccf2972d8b1